### PR TITLE
Use regular OSRM instructions by default, make Gemini opt-in

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -221,6 +221,24 @@ body,
   margin-right: 6px;
 }
 
+.gemini-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 4px 0;
+  user-select: none;
+}
+
+.gemini-toggle input[type="checkbox"] {
+  accent-color: var(--ttc-red);
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
 .navigate-btn {
   width: 100%;
   padding: clamp(10px, 2vw, 16px);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -31,6 +31,7 @@ export default function App() {
   const [panelOpen, setPanelOpen] = useState(true)
   const [isRouting, setIsRouting] = useState(false)
   const [activeTab, setActiveTab] = useState<'map' | 'navigate' | 'nearby' | 'alerts'>('map')
+  const [useGemini, setUseGemini] = useState(false)
 
   const handleFromSelect = useCallback((r: GeoResult) => {
     setFromCoords([r.lat, r.lng])
@@ -44,7 +45,7 @@ export default function App() {
     if (!fromCoords || !toCoords) return
     setIsRouting(true)
     try {
-      const result = await findRoute(fromCoords[0], fromCoords[1], toCoords[0], toCoords[1], toText)
+      const result = await findRoute(fromCoords[0], fromCoords[1], toCoords[0], toCoords[1], toText, useGemini)
       setRoute(result)
       setPanelOpen(true)
 
@@ -56,7 +57,7 @@ export default function App() {
     } finally {
       setIsRouting(false)
     }
-  }, [fromCoords, toCoords, toText])
+  }, [fromCoords, toCoords, toText, useGemini])
 
   const handleStationClick = useCallback(
     (station: Station, role: 'from' | 'to') => {
@@ -91,7 +92,7 @@ export default function App() {
       if (startCoords) {
         setIsRouting(true)
         try {
-          const result = await findRoute(startCoords[0], startCoords[1], station.lat, station.lng, station.name + ' Station')
+          const result = await findRoute(startCoords[0], startCoords[1], station.lat, station.lng, station.name + ' Station', useGemini)
           setRoute(result)
           setActiveTab('navigate')
           setPanelOpen(true)
@@ -103,7 +104,7 @@ export default function App() {
         setPanelOpen(true)
       }
     },
-    [route, userLocation],
+    [route, userLocation, useGemini],
   )
 
   const handleClear = useCallback(() => {
@@ -194,6 +195,14 @@ export default function App() {
                   onChange={setToText}
                   onSelect={handleToSelect}
                 />
+                <label className="gemini-toggle">
+                  <input
+                    type="checkbox"
+                    checked={useGemini}
+                    onChange={(e) => setUseGemini(e.target.checked)}
+                  />
+                  <span>✨ AI-enhanced directions</span>
+                </label>
                 <button
                   className="navigate-btn"
                   onClick={handleNavigate}
@@ -328,6 +337,14 @@ export default function App() {
                       onChange={setToText}
                       onSelect={handleToSelect}
                     />
+                    <label className="gemini-toggle">
+                      <input
+                        type="checkbox"
+                        checked={useGemini}
+                        onChange={(e) => setUseGemini(e.target.checked)}
+                      />
+                      <span>✨ AI-enhanced directions</span>
+                    </label>
                     <button
                       className="navigate-btn"
                       onClick={handleNavigate}

--- a/web/src/services/gemini.ts
+++ b/web/src/services/gemini.ts
@@ -139,7 +139,8 @@ export async function generateWalkingDirections(
   fromLng: number,
   toLat: number,
   toLng: number,
-  destinationName: string
+  destinationName: string,
+  useGemini: boolean = false
 ): Promise<{ instructions: string[]; path: [number, number][] }> {
   try {
     const osrmRes = await fetch(`https://router.project-osrm.org/route/v1/foot/${fromLng},${fromLat};${toLng},${toLat}?steps=true`)
@@ -167,6 +168,10 @@ export async function generateWalkingDirections(
 
         if (rawInstructions.length > 0) {
           const decodedPath = route.geometry ? polyline.decode(route.geometry as string) as [number, number][] : []
+
+          if (!useGemini) {
+            return { instructions: rawInstructions, path: decodedPath }
+          }
           
           const osrmContext = 'Here are the exact routing steps from the OSRM Turn-by-Turn API:\n' + rawInstructions.join('\n')
           const prompt = `You are a friendly, kind turn-by-turn walking navigation assistant in Toronto.

--- a/web/src/services/routing.ts
+++ b/web/src/services/routing.ts
@@ -28,7 +28,8 @@ export async function findRoute(
   fromLng: number,
   toLat: number,
   toLng: number,
-  destinationName: string = 'Destination'
+  destinationName: string = 'Destination',
+  useGemini: boolean = false
 ): Promise<Route | null> {
   console.log(`[findRoute] Executing route finding logic from [${fromLat}, ${fromLng}] to [${toLat}, ${toLng}]`)
   // Build a unified snapshot of the graph (Subways + Streetcars)
@@ -64,7 +65,7 @@ export async function findRoute(
 
   if (fromStation.id === toStation.id) {
     console.log(`[findRoute] Returning early. It's the same station! Generating walk steps.`)
-    const walkRes = await generateWalkingDirections(fromLat, fromLng, toLat, toLng, destinationName)
+    const walkRes = await generateWalkingDirections(fromLat, fromLng, toLat, toLng, destinationName, useGemini)
     return {
       steps: [
         {
@@ -149,8 +150,8 @@ export async function findRoute(
 
   // Generate walk instructions in parallel
   const [firstWalkRes, finalWalkRes] = await Promise.all([
-    generateWalkingDirections(fromLat, fromLng, fromStation.lat, fromStation.lng, fromStation.name),
-    generateWalkingDirections(toStation.lat, toStation.lng, toLat, toLng, destinationName)
+    generateWalkingDirections(fromLat, fromLng, fromStation.lat, fromStation.lng, fromStation.name, useGemini),
+    generateWalkingDirections(toStation.lat, toStation.lng, toLat, toLng, destinationName, useGemini)
   ])
 
   // Walk to first station


### PR DESCRIPTION
Navigation now uses free OSRM turn-by-turn instructions by default instead of always calling Gemini. Users can opt into AI-enhanced directions via a checkbox toggle before navigating.

Fixes #13