### PR TITLE
feat: route around closures and account for delays

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -45,7 +45,7 @@ export default function App() {
     if (!fromCoords || !toCoords) return
     setIsRouting(true)
     try {
-      const result = await findRoute(fromCoords[0], fromCoords[1], toCoords[0], toCoords[1], toText, useGemini)
+      const result = await findRoute(fromCoords[0], fromCoords[1], toCoords[0], toCoords[1], toText, useGemini, alertSegments)
       setRoute(result)
       setPanelOpen(true)
 
@@ -57,7 +57,7 @@ export default function App() {
     } finally {
       setIsRouting(false)
     }
-  }, [fromCoords, toCoords, toText, useGemini])
+  }, [fromCoords, toCoords, toText, useGemini, alertSegments])
 
   const handleStationClick = useCallback(
     (station: Station, role: 'from' | 'to') => {
@@ -92,7 +92,7 @@ export default function App() {
       if (startCoords) {
         setIsRouting(true)
         try {
-          const result = await findRoute(startCoords[0], startCoords[1], station.lat, station.lng, station.name + ' Station', useGemini)
+          const result = await findRoute(startCoords[0], startCoords[1], station.lat, station.lng, station.name + ' Station', useGemini, alertSegments)
           setRoute(result)
           setActiveTab('navigate')
           setPanelOpen(true)
@@ -104,7 +104,7 @@ export default function App() {
         setPanelOpen(true)
       }
     },
-    [route, userLocation, useGemini],
+    [route, userLocation, useGemini, alertSegments],
   )
 
   const handleClear = useCallback(() => {

--- a/web/src/services/routing.ts
+++ b/web/src/services/routing.ts
@@ -1,7 +1,7 @@
-import { graph as subwayGraph, getLineById, type GraphEdge } from '../data/lines'
+import { graph as subwayGraph, getLineById, lines, type GraphEdge } from '../data/lines'
 import { stationMap, type Station } from '../data/stations'
 import { fetchStreetcarRoutes, buildStreetcarGraphEdges } from './streetcars'
-import { generateWalkingDirections } from './gemini'
+import { generateWalkingDirections, type AffectedSegment } from './gemini'
 
 export interface RouteStep {
   type: 'walk' | 'ride' | 'transfer'
@@ -23,13 +23,43 @@ export interface Route {
   toStation: Station
 }
 
+/** Check if an edge falls within an affected segment and return its status. */
+function getEdgeStatus(
+  from: string,
+  to: string,
+  lineId: string,
+  alertSegments: AffectedSegment[]
+): AffectedSegment['status'] | null {
+  const line = lines.find(l => l.id === lineId)
+  if (!line) return null
+
+  for (const seg of alertSegments) {
+    if (seg.lineId !== lineId) continue
+    const segFromIdx = line.stationIds.indexOf(seg.fromStationId)
+    const segToIdx = line.stationIds.indexOf(seg.toStationId)
+    if (segFromIdx === -1 || segToIdx === -1) continue
+    const lo = Math.min(segFromIdx, segToIdx)
+    const hi = Math.max(segFromIdx, segToIdx)
+
+    const edgeFromIdx = line.stationIds.indexOf(from)
+    const edgeToIdx = line.stationIds.indexOf(to)
+    if (edgeFromIdx === -1 || edgeToIdx === -1) continue
+
+    if (edgeFromIdx >= lo && edgeFromIdx <= hi && edgeToIdx >= lo && edgeToIdx <= hi) {
+      return seg.status
+    }
+  }
+  return null
+}
+
 export async function findRoute(
   fromLat: number,
   fromLng: number,
   toLat: number,
   toLng: number,
   destinationName: string = 'Destination',
-  useGemini: boolean = false
+  useGemini: boolean = false,
+  alertSegments: AffectedSegment[] = []
 ): Promise<Route | null> {
   console.log(`[findRoute] Executing route finding logic from [${fromLat}, ${fromLng}] to [${toLat}, ${toLng}]`)
   // Build a unified snapshot of the graph (Subways + Streetcars)
@@ -108,10 +138,16 @@ export async function findRoute(
 
     const edges = unifiedGraph.get(current) ?? []
     for (const edge of edges) {
+      // Check if this edge is affected by a closure or delay
+      const status = getEdgeStatus(current, edge.to, edge.line, alertSegments)
+      if (status === 'closed') continue // skip closed edges entirely
+
       const prevEntry = prev.get(current)
       // Add penalty when switching lines (subway to streetcar, etc.)
       const transferPenalty = prevEntry && prevEntry.line !== edge.line ? 3 : 0
-      const newDist = minDist + edge.weight + transferPenalty
+      // Delayed edges cost 3x normal, diversions cost 2x
+      const disruptionMultiplier = status === 'delayed' ? 3 : status === 'diversion' ? 2 : 1
+      const newDist = minDist + (edge.weight * disruptionMultiplier) + transferPenalty
       if (newDist < (dist.get(edge.to) ?? Infinity)) {
         dist.set(edge.to, newDist)
         prev.set(edge.to, { stationId: current, line: edge.line })


### PR DESCRIPTION
fixes #18

## Changes
- **Closed segments**: Dijkstra skips them entirely, forcing alternate routes
- **Delayed segments**: 3x weight penalty so the algorithm prefers unaffected paths
- **Diversions**: 2x weight penalty
- Passes live alert segments from the app into the routing engine

The \getEdgeStatus()\ helper checks whether each graph edge falls within an affected segment's station range on the same line, matching against the Gemini-analyzed alert data already available in the app.