### PR TITLE
Mobile: clean map-only view on open + constant resize updates

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1411,12 +1411,29 @@ body,
   max-height: clamp(100px, 20vh, 160px);
 }
 
-/* Mobile: fix loading indicator above tab bar */
-.app-mobile .loc-loading {
-  bottom: calc(var(--tab-bar-h) + var(--sai-bottom) + 20px);
-  top: auto;
+/* Mobile: minimal loading indicator — small pill at top, doesn't block the map */
+.loc-loading-mobile {
+  position: fixed;
+  top: env(safe-area-inset-top, 12px);
+  bottom: auto;
   left: 50%;
   transform: translateX(-50%);
+  padding: 6px 14px;
+  font-size: 12px;
+  border-radius: 20px;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  z-index: 1100;
+}
+
+.loc-loading-mobile .loc-loading-spinner {
+  width: 12px;
+  height: 12px;
+  border-width: 2px;
+  border-top-color: #fff;
+  border-color: rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
 }
 
 /* Mobile: hide desktop-specific overlays */

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -131,8 +131,8 @@ export default function App() {
 
   return (
     <div className={`app ${isMobile ? 'app-mobile' : ''}`}>
-      {/* Offline banner */}
-      {!online && (
+      {/* Offline banner — hidden on mobile map view to keep it clean */}
+      {!online && !(isMobile && activeTab === 'map') && (
         <div className="offline-banner">
           📡 Offline Mode — Using cached data
           {!route && (
@@ -143,11 +143,11 @@ export default function App() {
         </div>
       )}
 
-      <VoiceoverToggle shiftRight={!!userLocation && !route} />
+      {!isMobile && <VoiceoverToggle shiftRight={!!userLocation && !route} />}
 
       {/* Location loading indicator */}
       {(locLoading || isRouting) && (
-        <div className="loc-loading">
+        <div className={`loc-loading ${isMobile ? 'loc-loading-mobile' : ''}`}>
           <span className="loc-loading-spinner" />
           {isRouting ? 'Generating route & walking directions...' : 'Getting your location…'}
         </div>

--- a/web/src/components/TTCMap.tsx
+++ b/web/src/components/TTCMap.tsx
@@ -42,6 +42,32 @@ function MapController({ route, userLocation }: { route: Route | null; userLocat
     }
   }, [route, map])
 
+  // Continuously invalidate map size on any resize / orientation change
+  useEffect(() => {
+    const container = map.getContainer()
+
+    const invalidate = () => map.invalidateSize({ animate: false })
+
+    // ResizeObserver for constant updates when container size changes
+    const ro = new ResizeObserver(invalidate)
+    ro.observe(container)
+
+    // Also listen to visualViewport changes (keyboard, pinch zoom on mobile)
+    const vv = window.visualViewport
+    if (vv) {
+      vv.addEventListener('resize', invalidate)
+      vv.addEventListener('scroll', invalidate)
+    }
+
+    return () => {
+      ro.disconnect()
+      if (vv) {
+        vv.removeEventListener('resize', invalidate)
+        vv.removeEventListener('scroll', invalidate)
+      }
+    }
+  }, [map])
+
   return null
 }
 

--- a/web/src/hooks/useBottomSheet.ts
+++ b/web/src/hooks/useBottomSheet.ts
@@ -67,7 +67,8 @@ export function useBottomSheet(opts: Options): BottomSheetHandle {
     if (typeof window === 'undefined') return 600
     const tabBar = document.querySelector('.mobile-tab-bar') as HTMLElement | null
     const tabBarH = tabBar ? tabBar.offsetHeight : 56
-    return window.innerHeight - tabBarH
+    const vh = window.visualViewport?.height ?? window.innerHeight
+    return vh - tabBarH
   }, [])
 
   const snapToTranslateY = useCallback(
@@ -224,13 +225,24 @@ export function useBottomSheet(opts: Options): BottomSheetHandle {
     [beginDrag],
   )
 
-  // Re-snap on window resize
+  // Re-snap on any viewport change (resize, orientation, virtual keyboard)
   useEffect(() => {
     const onResize = () => {
       setTranslateY(snapToTranslateY(snapsRef.current[snapIndex]))
     }
     window.addEventListener('resize', onResize)
-    return () => window.removeEventListener('resize', onResize)
+
+    const vv = window.visualViewport
+    if (vv) {
+      vv.addEventListener('resize', onResize)
+    }
+
+    return () => {
+      window.removeEventListener('resize', onResize)
+      if (vv) {
+        vv.removeEventListener('resize', onResize)
+      }
+    }
   }, [snapIndex, snapToTranslateY, setTranslateY])
 
   const style: React.CSSProperties = {


### PR DESCRIPTION
## Changes

**Clean mobile open experience:**
- Hide VoiceoverToggle on mobile (hover-based, not useful for touch)
- Hide offline banner when on the map tab to keep the view uncluttered
- Loading indicator replaced with a minimal translucent pill at the top

**Constant screen size updates:**
- Added ResizeObserver on Leaflet map container — fires on every pixel of resize, not just window resize events
- Added visualViewport listeners for keyboard show/hide and pinch zoom
- Bottom sheet hook now uses visualViewport.height and listens to its resize event for accurate, instant layout updates